### PR TITLE
env housekeeping + tests for nested OData read expressions

### DIFF
--- a/__tests__/lib/pg/service.test.js
+++ b/__tests__/lib/pg/service.test.js
@@ -111,7 +111,12 @@ describe('OData to Postgres dialect', () => {
     test('odata: $expand entityset on 1:n rel -> sql: sub-select multiple records from expand-target table', async () => {
       const response = await request.get('/beershop/Breweries?$expand=beers')
       expect(response.status).toStrictEqual(200)
-      // further assertions
+      expect(response.body.value.length).toBeGreaterThanOrEqual(2) // we have 2 beers
+      response.body.value.map((brewery) => {
+        expect(brewery.beers.length).toBeGreaterThanOrEqual(1) // every brewery has at least 1 beer
+        expect(brewery.beers[0].ID).toMatch(/\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/) // guid
+        expect(brewery.beers[0].name).toMatch(/\w+/)
+      })
     })
     test.todo('odata: $filter on $expand -> sql: select')
     test.todo('odata: multiple $ combined: $expand, $filter, $select -> sql: select')

--- a/__tests__/lib/pg/service.test.js
+++ b/__tests__/lib/pg/service.test.js
@@ -73,7 +73,7 @@ describe('OData to Postgres dialect', () => {
       expect(response.body.name).toStrictEqual('Schönramer Hell')
     })
 
-    test('odata: select -> sql: select record', async () => {
+    test('odata: $select -> sql: select record', async () => {
       const response = await request.get('/beershop/Beers(9e1704e3-6fd0-4a5d-bfb1-13ac47f7976b)?$select=name,ibu')
       // http response code
       expect(response.status).toStrictEqual(200)
@@ -82,7 +82,7 @@ describe('OData to Postgres dialect', () => {
       expect(response.body.name).toStrictEqual('Schönramer Hell')
     })
 
-    test('odata: select -> sql: select record', async () => {
+    test('odata: $filter -> sql: select record', async () => {
       const response = await request.get("/beershop/Beers?$filter=name eq 'Lagerbier Hell'")
 
       expect(response.status).toStrictEqual(200)
@@ -113,8 +113,6 @@ describe('OData to Postgres dialect', () => {
       expect(response.status).toStrictEqual(200)
       // further assertions
     })
-    test
-    test.todo('odata: $filter -> sql: select')
     test.todo('odata: $filter on $expand -> sql: select')
     test.todo('odata: multiple $ combined: $expand, $filter, $select -> sql: select')
   })

--- a/index.js
+++ b/index.js
@@ -53,8 +53,7 @@ const { readHandler, createHandler, updateHandler, deleteHandler, sqlHandler, cq
     this.before(['CREATE', 'UPDATE'], '*', managed)
     this.before(['CREATE', 'UPDATE'], '*', virtual)
     this.before(['CREATE', 'READ', 'UPDATE', 'DELETE'], '*', rewrite)
-    this.before(['CREATE', 'READ', 'UPDATE', 'DELETE'], '*', this._rewrite)
-    this.before(['CREATE', 'READ', 'UPDATE', 'DELETE'], '*', this.models)
+    this.before(['CREATE', 'READ', 'UPDATE', 'DELETE'], '*', this.setModel)
 
     /*
      * on
@@ -130,10 +129,11 @@ const { readHandler, createHandler, updateHandler, deleteHandler, sqlHandler, cq
     })
   }
 
-  /*
+  /**
    * assign request metadata
+   * @param {Object} req currently served express http request, enhanced by cds
    */
-  models(req) {
+  setModel(req) {
     this.models = req.context._model
   }
 
@@ -143,9 +143,6 @@ const { readHandler, createHandler, updateHandler, deleteHandler, sqlHandler, cq
   async acquire(arg) {
     // const tenant = (typeof arg === 'string' ? arg : arg.user.tenant) || 'anonymous'
     const dbc = await this._pool.connect()
-
-    // anything you need to do to prepare dbc
-
     return dbc
   }
 
@@ -161,7 +158,7 @@ const { readHandler, createHandler, updateHandler, deleteHandler, sqlHandler, cq
 
   // if needed
   async disconnect(tenant = 'anonymous') {
-    await custom_disconnect_function(tenant)
+    // potential await custom_disconnect_function(tenant)
     super.disconnect(tenant)
   }
 

--- a/index.js
+++ b/index.js
@@ -122,9 +122,9 @@ const { readHandler, createHandler, updateHandler, deleteHandler, sqlHandler, cq
      */
     this.on('*', function (req) {
       if (typeof req.query === 'string') {
-        return sqlHandler(this.dbc, req.query || req.event, this._model)
+        return sqlHandler(this.dbc, req.query || req.event, this.models)
       } else {
-        return cqnHandler(this.dbc, req.query || req.event, this._model)
+        return cqnHandler(this.dbc, req.query || req.event, this.models)
       }
     })
   }

--- a/lib/pg/execute.js
+++ b/lib/pg/execute.js
@@ -122,16 +122,17 @@ const processSimpleSQL = (dbc, cqn, model) => {
 }
 
 /**
- * Executes an SQL statement against the datbase.
- * @param {*} dbc
- * @param {*} sql
- * @param {*} values
+ * Executes an SQL statement against the database.
+ * @param {import('pg').PoolClient} dbc
+ * @param {String} sql
+ * @param {String} [values] optional; currently not used
  */
 function executeRawSQL(dbc, sql, values) {
   if (process.env.DEBUG || process.env.CDS_DEBUG) {
     console.info('[cds-pg]', '-', 'sql > ', sql)
+    values ? console.info('[cds-pg]', '-', 'values > ', values) : null
   }
-  return dbc.query(sql, values)
+  return dbc.query(sql)
 }
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cds-pg",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3795,9 +3795,9 @@
       }
     },
     "eslint": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.9.0.tgz",
-      "integrity": "sha512-V6QyhX21+uXp4T+3nrNfI3hQNBDa/P8ga7LoQOenwrlEFXrEnUEE+ok1dMtaS3b6rmLXhT1TkTIsG75HMLbknA==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.10.0.tgz",
+      "integrity": "sha512-BDVffmqWl7JJXqCjAK6lWtcQThZB/aP1HXSH1JKwGwv0LQEdvpR7qzNrUT487RM39B5goWuboFad5ovMBmD8yA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -3808,7 +3808,7 @@
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
-        "eslint-scope": "^5.1.0",
+        "eslint-scope": "^5.1.1",
         "eslint-utils": "^2.1.0",
         "eslint-visitor-keys": "^1.3.0",
         "espree": "^7.3.0",
@@ -5007,7 +5007,7 @@
       "dependencies": {
         "type-fest": {
           "version": "0.8.1",
-          "resolved": "https://nexus.rz.sys.aok.de/repository/npm-proxy/type-fest/-/type-fest-0.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
           "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
           "dev": true
         }
@@ -8477,7 +8477,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
       "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
-      "optional": true
+      "dev": true
     },
     "pretty-format": {
       "version": "25.5.0",
@@ -9301,7 +9301,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://nexus.rz.sys.aok.de/repository/npm-proxy/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         }
@@ -9873,63 +9873,72 @@
       "dev": true
     },
     "superagent": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
-      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
+      "integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
       "dev": true,
       "requires": {
-        "component-emitter": "^1.2.0",
-        "cookiejar": "^2.1.0",
-        "debug": "^3.1.0",
-        "extend": "^3.0.0",
-        "form-data": "^2.3.1",
-        "formidable": "^1.2.0",
-        "methods": "^1.1.1",
-        "mime": "^1.4.1",
-        "qs": "^6.5.1",
-        "readable-stream": "^2.3.5"
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.1",
+        "fast-safe-stringify": "^2.0.7",
+        "form-data": "^3.0.0",
+        "formidable": "^1.2.2",
+        "methods": "^1.1.2",
+        "mime": "^2.4.6",
+        "qs": "^6.9.4",
+        "readable-stream": "^3.6.0",
+        "semver": "^7.3.2"
       },
       "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "ms": "2.1.2"
           }
         },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "mime": {
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
           "dev": true
         },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
+        "qs": {
+          "version": "6.9.4",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+          "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
         }
       }
     },
     "supertest": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-4.0.2.tgz",
-      "integrity": "sha512-1BAbvrOZsGA3YTCWqbmh14L0YEq0EGICX/nBnfkfVJn7SrxQV1I3pMYjSzG9y/7ZU2V9dWqyqk2POwxlb09duQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-5.0.0.tgz",
+      "integrity": "sha512-2JAWpPrUOZF4hHH5ZTCN2xjKXvJS3AEwPNXl0HUseHsfcXFvMy9kcsufIHCNAmQ5hlGCvgeAqaR5PBEouN3hlQ==",
       "dev": true,
       "requires": {
-        "methods": "^1.1.2",
-        "superagent": "^3.8.3"
+        "methods": "1.1.2",
+        "superagent": "6.1.0"
       }
     },
     "supports-color": {
@@ -9970,25 +9979,25 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://nexus.rz.sys.aok.de/repository/npm-proxy/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "resolved": "https://nexus.rz.sys.aok.de/repository/npm-proxy/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
           "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://nexus.rz.sys.aok.de/repository/npm-proxy/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "https://nexus.rz.sys.aok.de/repository/npm-proxy/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
@@ -9999,7 +10008,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://nexus.rz.sys.aok.de/repository/npm-proxy/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -43,16 +43,17 @@
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
     "@types/jest": "^26.0.14",
-    "eslint": "^7.9.0",
+    "eslint": "^7.10.0",
     "eslint-plugin-jest": "^24.0.2",
     "express": "^4.17.1",
     "husky": "^4.3.0",
     "jest": "^26.4.2",
     "lint-staged": "^10.4.0",
     "npm-run-all": "^4.1.5",
+    "prettier": "2.1.2",
     "sqlite3": "^5.0.0",
     "standard-version": "^9.0.0",
-    "supertest": "^4.0.2"
+    "supertest": "^5.0.0"
   },
   "husky": {
     "hooks": {
@@ -69,9 +70,6 @@
       "/node_modules/",
       "<rootDir>/__tests__/__assets__/"
     ]
-  },
-  "optionalDependencies": {
-    "prettier": "2.1.2"
   },
   "prettier": {
     "semi": false,

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "testPathIgnorePatterns": [
       "/node_modules/",
       "<rootDir>/__tests__/__assets__/"
-    ]
+    ],
+    "testTimeout": 10000
   },
   "prettier": {
     "semi": false,

--- a/package.json
+++ b/package.json
@@ -62,6 +62,9 @@
     }
   },
   "lint-staged": {
+    "*.(js|json)": [
+      "prettier --write"
+    ],
     "*.js": "eslint --cache --fix"
   },
   "jest": {


### PR DESCRIPTION
this PR 
- refactors some of the runtime for being more explicit (elimination of unused vars) 
- does some house cleaning 
  - on npm module dependencies (updates, require `prettier`)
  - on re-formatting à la `prettier` pre-commit
- adds tests for complex and nested odata read queries (select on filtered expands)
