### PR TITLE
ci: rework publish release + npm package

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -33,13 +33,14 @@ jobs:
       # and tagging the release properly
       # and auto-incrementing the release number
       - run: npm run release
-      # push to self aka main from within gh action
+      # push to self aka main from within gh action with "release-state"
       # doesn't trigger this workflow again
       # b/c of missing personal access token here
       - run: |
           git config --global user.name 'SAP Mentors & Friends'
           git config --global user.email 'sapmentors@users.noreply.github.com'
           git push --follow-tags origin main
+      # finally publish the npm package
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,8 +6,6 @@ name: Node.js Package
 on:
   push:
     branches: [main]
-  release:
-    types: [created]
 
 jobs:
   build:
@@ -30,6 +28,18 @@ jobs:
           node-version: 12
           registry-url: https://registry.npmjs.org/
       - run: npm ci
+      # use standard-version for bumping versions in files,
+      # and generating changelog
+      # and tagging the release properly
+      # and auto-incrementing the release number
+      - run: npm run release
+      # push to self aka main from within gh action
+      # doesn't trigger this workflow again
+      # b/c of missing personal access token here
+      - run: |
+          git config --global user.name 'SAP Mentors & Friends'
+          git config --global user.email 'sapmentors@users.noreply.github.com'
+          git push --follow-tags origin main
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
extends the gh action to 
- cut a release via `standard-version`
  - bump package version (default: patch)
  - generate changelog
  - tag 
- publishes that release back to main branch 
- publish npm package 

given that gh actions can't really be tested upfront, might need some more polishing as we go along :)

(hopefully) closes #16 