### PR TITLE
ci(release): refactor workflow

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -1,0 +1,31 @@
+# do a release after ci user has pushed the tag to main
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - 'v*.*.*'
+jobs:
+  gh-release:
+    # only run on ci commits
+    if: "contains(github.event.head_commit.author.name, 'SAP Mentors & Friends')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        # read all commit messages since the last tag
+      - name: get commit messages
+      - run: |
+          LOG=`git log --oneline $(git describe --tags --abbrev=0 @^)..@`
+          echo "$LOG" > _BODY
+          echo ::set-env name=BODY::${_BODY}
+      - name: set tag to env var
+        run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/}
+      - uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.RELEASE_VERSION }}
+          release_name: Release ${{ env.RELEASE_VERSION }}
+          body: ${{ env.BODY }}
+          draft: false
+          prerelease: false

--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
         # read all commit messages since the last tag
       - name: get commit messages
-      - run: |
+        run: |
           LOG=`git log --oneline $(git describe --tags --abbrev=0 @^)..@`
           echo "$LOG" > _BODY
           echo ::set-env name=BODY::${_BODY}

--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -2,7 +2,6 @@
 
 on:
   push:
-    branches: [main]
     tags:
       - 'v*.*.*'
 jobs:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,5 +1,4 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+# publish cds-pg npm package
 
 name: Node.js Package
 
@@ -9,7 +8,7 @@ on:
 
 jobs:
   build:
-    # only run on non-ci commits 
+    # only run on non-ci commits
     if: "!contains(github.event.head_commit.author.name, 'SAP Mentors & Friends')"
     runs-on: ubuntu-latest
     steps:
@@ -21,7 +20,7 @@ jobs:
       - run: npm test
 
   publish-npm:
-    # only run on non-ci commits 
+    # only run on non-ci commits
     if: "!contains(github.event.head_commit.author.name, 'SAP Mentors & Friends')"
     needs: build
     runs-on: ubuntu-latest
@@ -50,24 +49,3 @@ jobs:
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-
-  gh-release:
-    # only run on non-ci commits 
-    if: "!contains(github.event.head_commit.author.name, 'SAP Mentors & Friends')"
-    needs: [publish-npm]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        # read all commit messages since the last tag
-      - run: |
-           LOG=`git log --oneline $(git describe --tags --abbrev=0 @^)..@`
-           echo "$LOG" > BODY
-      - uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          body: $(cat BODY)
-          draft: false
-          prerelease: false


### PR DESCRIPTION
- exctract gh release to separate action
- only run action on tags pushed to main,
   and only if the ci-user pushes the tag
- try to inject gh release body via env var

**only merge to `main` prior to next feature-PR, not stand-alone
as this will trigger another release cycle - which we don't want for this PR**