### PR TITLE
Fix for Issue #263: Fixed tags in default-env.json example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For a short introduction on the background of this project you can check out [a 
 
 ## Current status
 
-**_cds-pg_ is ready to be used!**  
+**_cds-pg_ is ready to be used!**
 Still, there's some gaps left to fill - note the list below and please see [`CONTRIBUTING.md`](./docs/CONTRIBUTING.md) for how to contribute additional capabilities!
 
 Also checkout the following blog posts on how to get started using `cds-pg` in your local development environment and on SAP Business Technology Platform (BTP), Cloud Foundry:
@@ -81,9 +81,7 @@ For local development you can provide the credentials in the file `default-env.j
       {
         "name": "postgres",
         "label": "postgres",
-        "tags": [
-          "postgres"
-        ],
+        "tags": ["plain", "database"],
         "credentials": {
           "host": "localhost",
           "port": "5432",


### PR DESCRIPTION
I have fixed the tags in the default-env.json example to match the template in the CAP application used for testing.

I have also dug deeper into CAP to understand, what happens. The root cause, why the "plain" dialect is important in the tags of the VACP services is, that the configuration for the "postgres" service is merged with the "db" service - and when the VACP settings are merged, the current service name is "db" - not "postgres".

The magic happens in `_add_vcap_services_to` of @sap/cds/lib/env/index.js.

I can amend the pull request and try to explain the matching of the services is more detail if required.

Kind regards,
Sebastian