### PR TITLE
fix: return null when SELECT.one returns empty result 

### DIFF
--- a/__tests__/lib/pg/ql.test.js
+++ b/__tests__/lib/pg/ql.test.js
@@ -5,7 +5,7 @@ const deploy = require('@sap/cds/lib/deploy')
 cds.env.requires.db = { kind: 'postgres' }
 cds.env.requires.postgres = {
   dialect: 'plain',
-  impl: './cds-pg', // hint: not really sure as to why this is, but...
+  impl: './cds-pg' // hint: not really sure as to why this is, but...
 }
 
 jest.setTimeout(100000)
@@ -22,8 +22,8 @@ describe('QL to PostgreSQL', () => {
         port: '5432',
         database: 'beershop',
         username: 'postgres',
-        password: 'postgres',
-      },
+        password: 'postgres'
+      }
     }
     cds.db = await cds.connect.to(this._dbProperties)
   })
@@ -59,6 +59,13 @@ describe('QL to PostgreSQL', () => {
       )
       expect(beer).toHaveProperty('ID', '9e1704e3-6fd0-4a5d-bfb1-13ac47f7976b')
       expect(beer).not.toHaveProperty('abv')
+    })
+
+    test('-> with one - no result returns null not empty array', async () => {
+      const { Beers } = cds.entities('csw')
+      const beer = await cds.run(SELECT.one(Beers).where({ name: 'does not exist' }))
+      expect(beer).not.toBeInstanceOf(Array)
+      expect(beer).toBeNull()
     })
 
     test.todo('-> with distinct')

--- a/lib/pg/execute.js
+++ b/lib/pg/execute.js
@@ -96,7 +96,7 @@ const executeInsertCQN = async (model, dbc, cqn, user) => {
 async function executePlainSQL(dbc, rawSql, rawValues) {
   const { sql, values } = _replacePlaceholders({
     sql: rawSql,
-    values: rawValues,
+    values: rawValues
   })
 
   DEBUG && DEBUG('sql > ', sql)
@@ -149,11 +149,11 @@ function _cqnToSQL(model, cqn, user, isExpand = false) {
           SelectBuilder: PGSelectBuilder,
           ResourceBuilder: PGResourceBuilder,
           ExpressionBuilder: PGExpressionBuilder,
-          FunctionBuilder: PGFunctionBuilder,
+          FunctionBuilder: PGFunctionBuilder
         },
         isExpand, // Passed to inform the select builder that we are dealing with an expand call
         now: 'NOW ()',
-        user,
+        user
       },
       model,
       isExpand
@@ -210,7 +210,14 @@ async function _executeSQLReturningRows(dbc, sql, values, isOne, postMapper, pro
   DEBUG && values && values.length > 0 && DEBUG('values > ', values)
 
   let rawResult = await dbc.query(sql, values)
-  const result = isOne && rawResult.rows.length > 0 ? rawResult.rows[0] : rawResult.rows
+  let result
+  if (isOne && rawResult.rows.length > 0) {
+    result = rawResult.rows[0]
+  } else if (isOne && rawResult.rows.length === 0) {
+    result = null
+  } else {
+    result = rawResult.rows
+  }
   return postProcess(result, postMapper, propertyMapper, objStructMapper)
 }
 
@@ -226,5 +233,5 @@ module.exports = {
   read: executeSelectCQN,
   //stream: executeSelectStreamCQN,
   cqn: executeGenericCQN,
-  sql: executePlainSQL,
+  sql: executePlainSQL
 }


### PR DESCRIPTION
Currently cds-pg returns an empty array is SELECT.one returns no result. CAP returns null when SELECT.one for SQLite and HANA has no result.

@gregorwolf @vobu 