### PR TITLE
fix: return timestamps, not now() for createdAt and modifiedAt columns

### DIFF
--- a/__tests__/lib/pg/ql.test.js
+++ b/__tests__/lib/pg/ql.test.js
@@ -157,5 +157,29 @@ describe('QL to PostgreSQL', () => {
       const beer = await cds.run(SELECT.one(Beers).where({ name: 'Test' }))
       expect(beer).toHaveProperty('name', 'Test')
     })
+
+    // see https://cap.cloud.sap/docs/node.js/databases#insertresult-beta and https://answers.sap.com/questions/13569793/api-of-insert-query-results-for-cap-nodejs.html
+    test('-> with InsertResult Beta API', async () => {
+      const { Beers } = cds.entities('csw')
+
+      const entries = [
+        { name: 'Beer1', abv: 1.0, ibu: 1, brewery_ID: '0465e9ca-6255-4f5c-b8ba-7439531f8d28' },
+        { name: 'Beer2', abv: 2.0, ibu: 2, brewery_ID: '0465e9ca-6255-4f5c-b8ba-7439531f8d28' },
+        { name: 'Beer3', abv: 3.0, ibu: 3, brewery_ID: '0465e9ca-6255-4f5c-b8ba-7439531f8d28' }
+      ]
+
+      const uuidRegex = /[\d|a-f]{8}-[\d|a-f]{4}-[\d|a-f]{4}-[\d|a-f]{4}-[\d|a-f]{12}/
+      const timestampRegex = /[\d]{4}-[\d]{2}-[\d]{2}T[\d]{2}:[\d]{2}:[\d]{2}.[\d]{3}Z/
+
+      const insertResult = await cds.run(INSERT.into(Beers).entries(entries))
+      expect(insertResult.affectedRows).toStrictEqual(3)
+      expect(insertResult == 3).toStrictEqual(true)
+      expect(insertResult.valueOf()).toStrictEqual(insertResult.affectedRows)
+      const beers = [...entries]
+      expect(beers.length).toStrictEqual(3)
+      expect(beers[0].ID).toMatch(uuidRegex)
+      expect(beers[0].createdAt).toMatch(timestampRegex)
+      expect(beers[0].modifiedAt).toMatch(timestampRegex)
+    })
   })
 })

--- a/lib/pg/execute.js
+++ b/lib/pg/execute.js
@@ -23,8 +23,8 @@ const DEBUG = cds.debug('cds-pg')
  * @param {*} txTimestamp
  * @return {import('pg').QueryArrayResult}
  */
-const executeGenericCQN = (model, dbc, query, user /*, locale, txTimestamp */) => {
-  const { sql, values = [] } = _cqnToSQL(model, query, user)
+const executeGenericCQN = (model, dbc, query, user, locale, txTimestamp) => {
+  const { sql, values = [] } = _cqnToSQL(model, query, user, locale, txTimestamp)
   const isOne = query.SELECT && query.SELECT.one
   const postPropertyMapper = getPostProcessMapper(PG_TYPE_CONVERSION_MAP, model, query)
   return _executeSQLReturningRows(dbc, sql, values, isOne, postPropertyMapper)
@@ -41,11 +41,11 @@ const executeGenericCQN = (model, dbc, query, user /*, locale, txTimestamp */) =
  * @param {*} txTimestamp
  * @return {import('pg').QueryArrayResult}
  */
-const executeSelectCQN = (model, dbc, query, user /*, locale, txTimestamp*/) => {
+const executeSelectCQN = (model, dbc, query, user, locale, txTimestamp) => {
   if (hasExpand(query)) {
-    return processExpand(dbc, query, model, user)
+    return processExpand(dbc, query, model, user, locale, txTimestamp)
   } else {
-    const { sql, values = [] } = _cqnToSQL(model, query, user)
+    const { sql, values = [] } = _cqnToSQL(model, query, user, locale, txTimestamp)
     const isOne = query.SELECT && query.SELECT.one
     const postPropertyMapper = getPostProcessMapper(PG_TYPE_CONVERSION_MAP, model, query)
     return _executeSQLReturningRows(dbc, sql, values, isOne, postPropertyMapper)
@@ -65,8 +65,8 @@ const executeSelectCQN = (model, dbc, query, user /*, locale, txTimestamp*/) => 
  * @param {*} txTimestamp
  * @return {Array}
  */
-const executeInsertCQN = async (model, dbc, cqn, user) => {
-  const { sql, values = [] } = _cqnToSQL(model, cqn, user)
+const executeInsertCQN = async (model, dbc, cqn, user, locale, txTimestamp) => {
+  const { sql, values = [] } = _cqnToSQL(model, cqn, user, locale, txTimestamp)
   const postPropertyMapper = getPostProcessMapper(PG_TYPE_CONVERSION_MAP, model, cqn)
   const resultPromises = []
 
@@ -116,13 +116,13 @@ async function executePlainSQL(dbc, rawSql, rawValues) {
  * @param {*} user
  * @return {import('pg').QueryArrayResult} the
  */
-const processExpand = (dbc, cqn, model, user) => {
+const processExpand = (dbc, cqn, model, user, locale, txTimestamp) => {
   let queries = []
   const expandQueries = createJoinCQNFromExpanded(cqn, model, true)
   for (const cqn of expandQueries.queries) {
     // REVISIT
     // Why is the post processing in expand different?
-    const { sql, values } = _cqnToSQL(model, cqn, user, true)
+    const { sql, values } = _cqnToSQL(model, cqn, user, locale, txTimestamp, true)
     const postPropertyMapper = getPostProcessMapper(PG_TYPE_CONVERSION_MAP, model, cqn)
 
     queries.push(_executeSQLReturningRows(dbc, sql, values, false, postPropertyMapper))
@@ -140,7 +140,7 @@ const processExpand = (dbc, cqn, model, user) => {
  * @param {Boolean} isExpand
  * @return {Object} the query object containing sql and values
  */
-function _cqnToSQL(model, cqn, user, isExpand = false) {
+function _cqnToSQL(model, cqn, user, locale, txTimestamp, isExpand = false) {
   return _replacePlaceholders(
     sqlFactory(
       cqn,
@@ -152,8 +152,9 @@ function _cqnToSQL(model, cqn, user, isExpand = false) {
           FunctionBuilder: PGFunctionBuilder
         },
         isExpand, // Passed to inform the select builder that we are dealing with an expand call
-        now: 'NOW ()',
-        user
+        now: txTimestamp || { sql: 'NOW ()' },
+        user,
+        locale
       },
       model,
       isExpand
@@ -221,8 +222,8 @@ async function _executeSQLReturningRows(dbc, sql, values, isOne, postMapper, pro
   return postProcess(result, postMapper, propertyMapper, objStructMapper)
 }
 
-const executeUpdateCQN = async (model, dbc, cqn) => {
-  const result = await executeGenericCQN(model, dbc, cqn)
+const executeUpdateCQN = async (model, dbc, cqn, user, locale, txTimestamp) => {
+  const result = await executeGenericCQN(model, dbc, cqn, user, locale, txTimestamp)
   return Array.isArray(result) ? result.length : result
 }
 


### PR DESCRIPTION
Hi @vobu and @gregorwolf, 

cds-pg returned NOW() instead of a timestamp for createdAt and modifiedAt columns when used as described in the new InsertResult Beta documentation at https://cap.cloud.sap/docs/node.js/databases#insertresult-beta.

I compared the behaviour of cds-pg vs. HANA and SQLite here: https://answers.sap.com/questions/13569793/api-of-insert-query-results-for-cap-nodejs.html

I have to admit I don't understand, why the locale and txTimestamp parameters were omitted from the exported functions in lib/pg/execute.js, but adding them fixed the issue and all tests are completed successfully.

Cheers,
Sebastian