### PR TITLE
fix: date conversion using correct time zone ref

### DIFF
--- a/__tests__/lib/pg/service-types.test.js
+++ b/__tests__/lib/pg/service-types.test.js
@@ -5,7 +5,7 @@ const deploy = require('@sap/cds/lib/dbs/cds-deploy')
 cds.env.requires.db = { kind: 'postgres' }
 cds.env.requires.postgres = {
   dialect: 'plain',
-  impl: './cds-pg', // hint: not really sure as to why this is, but...
+  impl: './cds-pg' // hint: not really sure as to why this is, but...
 }
 
 // default (single) test environment is local,
@@ -23,7 +23,7 @@ describe.each(suiteEnvironments)(
       this._dbProperties = {
         kind: 'postgres',
         model: this._model,
-        credentials: credentials,
+        credentials: credentials
       }
 
       // only bootstrap in local mode as scp app is deployed and running
@@ -44,21 +44,21 @@ describe.each(suiteEnvironments)(
     describe('OData types: CREATE', () => {
       test(' -> Boolean', async () => {
         const response = await request.post('/beershop/TypeChecks').send({
-          type_Boolean: true,
+          type_Boolean: true
         })
         expect(response.status).toStrictEqual(201)
       })
 
       test(' -> Int32', async () => {
         const response = await request.post('/beershop/TypeChecks').send({
-          type_Int32: 10,
+          type_Int32: 10
         })
         expect(response.status).toStrictEqual(201)
       })
 
       test(' -> Int64', async () => {
         const response = await request.post('/beershop/TypeChecks').send({
-          type_Int64: 1000000000000,
+          type_Int64: 1000000000000
         })
         expect(response.status).toStrictEqual(201)
       })
@@ -67,7 +67,7 @@ describe.each(suiteEnvironments)(
         const response = await request
           .post('/beershop/TypeChecks')
           .send({
-            type_Decimal: '3.1',
+            type_Decimal: '3.1'
           })
           .set('content-type', 'application/json;charset=UTF-8;IEEE754Compatible=true')
         expect(response.status).toStrictEqual(201)
@@ -75,28 +75,29 @@ describe.each(suiteEnvironments)(
 
       test(' -> Double', async () => {
         const response = await request.post('/beershop/TypeChecks').send({
-          type_Double: 23423.1234234,
+          type_Double: 23423.1234234
         })
         expect(response.status).toStrictEqual(201)
       })
 
       test(' -> Date', async () => {
         const response = await request.post('/beershop/TypeChecks').send({
-          type_Date: '2015-12-31',
+          type_Date: '2015-12-31'
         })
         expect(response.status).toStrictEqual(201)
+        expect(response.body.type_Date).toStrictEqual('2015-12-31')
       })
 
       test(' -> Time', async () => {
         const response = await request.post('/beershop/TypeChecks').send({
-          type_Time: '10:21:15',
+          type_Time: '10:21:15'
         })
         expect(response.status).toStrictEqual(201)
       })
 
       test(' -> DateTime', async () => {
         const response = await request.post('/beershop/TypeChecks').send({
-          type_DateTime: '2012-12-03T07:16:23.574Z',
+          type_DateTime: '2012-12-03T07:16:23.574Z'
         })
         expect(response.status).toStrictEqual(201)
       })
@@ -104,7 +105,7 @@ describe.each(suiteEnvironments)(
       test(' -> Timestamp', async () => {
         const value = '2012-12-03T07:16:23.574Z'
         const response = await request.post('/beershop/TypeChecks').send({
-          type_Timestamp: value,
+          type_Timestamp: value
         })
         expect(response.status).toStrictEqual(201)
         const verify = await request.get(`/beershop/TypeChecks(${response.body.ID})`).send()
@@ -113,21 +114,21 @@ describe.each(suiteEnvironments)(
 
       test(' -> String', async () => {
         const response = await request.post('/beershop/TypeChecks').send({
-          type_String: 'Hello World',
+          type_String: 'Hello World'
         })
         expect(response.status).toStrictEqual(201)
       })
 
       test(' -> Binary', async () => {
         const response = await request.post('/beershop/TypeChecks').send({
-          type_Binary: 'SGVsbG8gV29ybGQ=',
+          type_Binary: 'SGVsbG8gV29ybGQ='
         })
         expect(response.status).toStrictEqual(201)
       })
 
       test(' -> LargeBinary', async () => {
         const response = await request.post('/beershop/TypeChecks').send({
-          type_LargeBinary: 'SGVsbG8gV29ybGQ=',
+          type_LargeBinary: 'SGVsbG8gV29ybGQ='
         })
         expect(response.status).toStrictEqual(201)
       })
@@ -135,10 +136,20 @@ describe.each(suiteEnvironments)(
       test(' -> LargeString', async () => {
         const response = await request.post('/beershop/TypeChecks').send({
           type_LargeString:
-            'Magna sit do quis culpa elit laborum culpa laboris excepteur. Proident qui culpa mollit ut ad enim. Reprehenderit aute occaecat ut ut est nostrud aliquip.',
+            'Magna sit do quis culpa elit laborum culpa laboris excepteur. Proident qui culpa mollit ut ad enim. Reprehenderit aute occaecat ut ut est nostrud aliquip.'
         })
         expect(response.status).toStrictEqual(201)
       })
     })
-  },
+    describe('OData types: READ', () => {
+      test(' -> Date', async () => {
+        const date = '2015-01-01'
+        const response = await request.post('/beershop/TypeChecks').send({
+          type_Date: date
+        })
+        expect(response.status).toStrictEqual(201)
+        expect(response.body.type_Date).toStrictEqual(date)
+      })
+    })
+  }
 )

--- a/lib/pg/converters/conversion.js
+++ b/lib/pg/converters/conversion.js
@@ -1,5 +1,3 @@
-const moment = require('moment')
-
 const convertToBoolean = (boolean) => {
   if (boolean === null) {
     return null
@@ -22,7 +20,7 @@ const convertToDate = (date) => {
   }
 
   const d = new Date(date + 'Z')
-  return moment(d).format('YYYY-MM-DD')
+  return d.toISOString().substring(0, 10)
 }
 
 const convertInt64ToString = (int64) => {
@@ -75,9 +73,9 @@ const PG_TYPE_CONVERSION_MAP = new Map([
   ['cds.Date', convertToDate],
   ['cds.Binary', convertToBinary],
   ['cds.LargeBinary', convertToBinary],
-  ['cds.Double', convertToDouble],
+  ['cds.Double', convertToDouble]
 ])
 
 module.exports = {
-  PG_TYPE_CONVERSION_MAP,
+  PG_TYPE_CONVERSION_MAP
 }


### PR DESCRIPTION
This request is related to #387 in which date types from the database are converted to the previous day for timezones west of UTC. 

This update contains the following.
* Conversion of UTC timestamp to UTC date string.
* Use of JS function `toISOString()` as opposed to `moment()` - See #369 
* Added READ section in Service Types testing for Date. Not sure about the convention to use here. I replicated the OData create, used in the previous section. The resulting response body seems to go through the same conversion.

Note: The prettier settings did remove trailing commas from the files I edited. 
```JS
module.exports = {
  semi: false,
  printWidth: 120,
  arrowParens: 'always',
  trailingComma: 'none',
  singleQuote: true,
  tabWidth: 2,
  proseWrap: 'never'
}
```